### PR TITLE
Template fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Complete the following steps to run the template and provision resources on Azur
 
 1. [Install the Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd) on your device.
 
+1. [Install Docker Desktop](https://www.docker.com/products/docker-desktop/) on your device. This is needed to package the container app.
+
 1. In the command line tool of your choice, run the [`azd init`](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/reference#azd-init) command to clone and initialize this template repo.
 
     ```bash

--- a/infra/app/app.bicep
+++ b/infra/app/app.bicep
@@ -13,6 +13,9 @@ param exists bool
 @description('Endpoint for Azure Cosmos DB for NoSQL account.')
 param databaseAccountEndpoint string
 
+@description('Blob endpoint for Azure Storage account.')
+param storageAccountBlobEndpoint string
+
 type managedIdentity = {
   resourceId: string
   clientId: string
@@ -32,6 +35,7 @@ module containerAppsApp '../core/host/container-app.bicep' = {
     secrets: {
         'azure-cosmos-db-nosql-endpoint': databaseAccountEndpoint
         'azure-managed-identity-client-id':  userAssignedManagedIdentity.clientId
+        'azure-storage-blob-endpoint': storageAccountBlobEndpoint
       }
     env: [
       {
@@ -41,6 +45,10 @@ module containerAppsApp '../core/host/container-app.bicep' = {
       {
         name: 'AZURE_MANAGED_IDENTITY_CLIENT_ID'
         secretRef: 'azure-managed-identity-client-id'
+      }
+      {
+        name: 'STORAGE_URL'
+        secretRef: 'azure-storage-blob-endpoint'
       }
     ]
     targetPort: 8080

--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -99,3 +99,4 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
 output id string = storage.id
 output name string = storage.name
 output primaryEndpoints object = storage.properties.primaryEndpoints
+output blobEndpoint string = storage.properties.primaryEndpoints.blob

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -129,6 +129,7 @@ module web 'app/app.bicep' = {
   params: {
     appName: !empty(containerAppsAppName) ? containerAppsAppName : '${abbrs.appContainerApps}${resourceToken}'
     databaseAccountEndpoint: cosmos.outputs.endpoint
+    storageAccountBlobEndpoint: storage.outputs.blobEndpoint
     containerAppsEnvironmentName: containerAppsEnv.outputs.environmentName
     containerRegistryName: containerAppsEnv.outputs.registryName
     userAssignedManagedIdentity: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -47,6 +47,7 @@ var resourceToken = toLower(uniqueString(subscription().id, environmentName, loc
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: !empty(resourceGroupName) ? resourceGroupName : '${abbrs.resourcesResourceGroups}${environmentName}'
   location: location
+  tags: tags
 }
 
 // Add resources to be provisioned below.

--- a/src/Components/Pages/Demo.razor
+++ b/src/Components/Pages/Demo.razor
@@ -14,7 +14,7 @@
             <MudDivider Class="my-6" />
         </MudItem>
         <MudPaper Class="my-6 pa-6">
-            The azd template deployed a sample app to Azure App Service and provisioned supporting resources. To test the app, fill out the form, select an attachment, and then click submit. The form data will be stored in Azure CosmosDB for NoSQL and the file will be stored in Blob Storage.
+            The azd template deployed a sample app to Azure App Service and provisioned supporting resources. To test the app, fill out the form, select an attachment (must be smaller than 0.5 MB), and then click submit. The form data will be stored in Azure CosmosDB for NoSQL and the file will be stored in Blob Storage.
         </MudPaper>
         <MudPaper Class="pa-4">
             <EditForm Model="ticket" OnValidSubmit="Submit">
@@ -26,8 +26,8 @@
                 <MudFileUpload Label="Attachment" Class="mt-3 mb-6" OnFilesChanged="SetFile" T="IBrowserFile">
                     <ActivatorContent>
                         <MudButton Variant="Variant.Filled"
-                                   Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.CloudUpload">
+                        Color="Color.Primary"
+                        StartIcon="@Icons.Material.Filled.CloudUpload">
                             Upload Attachment
                         </MudButton><MudText>@fileName</MudText>
                     </ActivatorContent>
@@ -49,6 +49,7 @@
                     {
                         <MudText Color="@Color.Error">
                             <ValidationSummary />
+                            @error
                         </MudText>
                     }
                 </div>
@@ -168,15 +169,16 @@
 
             tickets.Add(item);
             loading = false;
+            error = "";
+            success = true;
+            ticket = new();
+            fileName = "";
         }
         catch (Exception e)
         {
             loading = false;
             error = e.Message;
+            success = false;
         }
-
-        success = true;
-        ticket = new();
-        fileName = "";
     }
 } 


### PR DESCRIPTION
Fixes #3.
Fixes #4.

This PR:

- fixes an issue with `azd up` where the deployed container would fail to start due to a missing `STORAGE_URL` environment variable.

- fixes an issue with `azd down` where it would fail to detect or delete the provisioned Azure resources due to the `azd-env-name` tag not being set on the Azure resource group.

- improves the error handling in the demo app so that the exception message is displayed and form fields don't get cleared:

    ![image](https://github.com/user-attachments/assets/405803a2-bdfc-4fca-ab0a-57e50e8d6dcd)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

**Setup:**
1. `git clone https://github.com/JeffreyCA/hello-azd.git`
1. `cd hello-azd`
1. `git checkout template-fixes`


**Test the code:**
<!-- Add steps to run the tests suite and/or manually test -->
1. `azd up`
1. Verify that the container endpoint is accessible and web app works as expected
1. `azd down`
1. Verify that the provisioned Azure resources are properly deleted


## What to Check

* Verify that the container endpoint is accessible and web app works as expected
* Verify that the provisioned Azure resources are properly deleted
* Verify that a red error message is displayed in the demo app when attempting to upload a file greater than 0.5 MB
